### PR TITLE
Launcher script breaks at high numbers of sites (#414)

### DIFF
--- a/launcher
+++ b/launcher
@@ -335,7 +335,12 @@ set_template_info() {
     puts env.map{|k,v| "-e\n#{k}=#{v}" }.join("\n")
 RUBY
 
-    raw=`exec echo "$input" | $docker_path run $user_args --rm -i -a stdin -a stdout $image ruby -e "$env_ruby"`
+    tmp_input_file=$(mktemp)
+
+    echo "$input" > "$tmp_input_file"
+    raw=`exec cat "$tmp_input_file" | $docker_path run $user_args --rm -i -a stdin -a stdout $image ruby -e "$env_ruby"`
+
+    rm -f "$tmp_input_file"
 
     env=()
     ok=1
@@ -374,7 +379,12 @@ RUBY
     puts labels.map{|k,v| "-l\n#{k}=#{v}" }.join("\n")
 RUBY
 
-    raw=`exec echo "$input" | $docker_path run $user_args --rm -i -a stdin -a stdout $image ruby -e "$labels_ruby"`
+    tmp_input_file=$(mktemp)
+
+    echo "$input" > "$tmp_input_file"
+    raw=`exec cat "$tmp_input_file" | $docker_path run $user_args --rm -i -a stdin -a stdout $image ruby -e "$labels_ruby"`
+
+    rm -f "$tmp_input_file"
 
     labels=()
     ok=1
@@ -622,8 +632,14 @@ run_bootstrap() {
   echo $run_command
 
   unset ERR
-  (exec echo "$input" | $docker_path run --shm-size=512m $user_args $links "${env[@]}" -e DOCKER_HOST_IP="$docker_ip" --cidfile $cidbootstrap -i -a stdin -a stdout -a stderr $volumes $image \
+
+  tmp_input_file=$(mktemp)
+
+  echo "$input" > "$tmp_input_file"
+  (exec cat "$tmp_input_file" | $docker_path run --shm-size=512m $user_args $links "${env[@]}" -e DOCKER_HOST_IP="$docker_ip" --cidfile $cidbootstrap -i -a stdin -a stdout -a stderr $volumes $image \
     /bin/bash -c "$run_command") || ERR=$?
+
+  rm -f "$tmp_input_file"
 
   unset FAILED
   # magic exit code that indicates a retry


### PR DESCRIPTION
On a multi-site app configuration files such as containers/web.yml
grow with the number of sites. We discovered that the launcher script breaks
at around 100 sites due to "Argument List too long" when
commands such 'echo' are being referenced from the within the exec
call.

This workaround echoes the "$input" content outside the exec (which we verified
works fine for 300 sites) and then cats the file content inside the
exec. Thus bypassing the argument limitation. Finally, we remove the temporary file generated.